### PR TITLE
Adding a disable attribute which will prevent a user from closing the modal is disable it true

### DIFF
--- a/akyral-modal-behavior.js
+++ b/akyral-modal-behavior.js
@@ -97,6 +97,13 @@
       },
 
       /**
+       * defines the ability to disable closing the modal
+       */
+      disableClose: {
+        type: Boolean
+      },
+
+      /**
        * defines the visibility state of the component
        */
       shown: {
@@ -137,9 +144,12 @@
     },
 
     /**
-     * closes the modal
+     * closes the modal if not disabled.
      */
     close: function() {
+      if (this.disable) {
+        return;
+      }
       this.shown = false;
     },
 


### PR DESCRIPTION
Sometimes you want to prevent a user from closing the modal with the escape button and instead direct them somewhere else.  This disable attribute can prevent the user from closing modal either by click the close button or using keyboard escape key to close the modal.
