### PR TITLE
fixes issue with document body being unscrollable after closing multiple modals

### DIFF
--- a/akyral-modal-behavior.js
+++ b/akyral-modal-behavior.js
@@ -68,7 +68,7 @@
    */
   function swapAndResetFocus() {
     this._parentEl.replaceChild(this, this._placeholder);
-    docEl.style.overflow = lastOverflow;
+    docEl.style.overflow = !lastModal.shown ? '' : lastOverflow;
     lastFocus.focus();
   }
 


### PR DESCRIPTION
If you have multiple modals that open one after the other, when you close the last modal the page is not scrollable.  The style for the body is set to `overflow: hidden` when the modals are swapped. When the last modal is closed the `overflow: hidden` is not being removed from the body, making the page not scrollable, until a user refreshes the page.

This fix will resolve that issue.